### PR TITLE
fix: wrong uri for external module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "flarum/core": "^1.2.0"
+    "flarum/core": "^1.5.0"
   },
   "replace": {
     "wiseclock/flarum-ext-profile-image-crop": "*"

--- a/js/src/forum/external/modules.js
+++ b/js/src/forum/external/modules.js
@@ -1,6 +1,6 @@
 import app from 'flarum/forum/app';
 
-const prepare = () => (__webpack_public_path__ = `${app.forum.attribute('baseUrl')}/assets/extensions/fof-profile-image-crop/`);
+const prepare = () => (__webpack_public_path__ = `${app.forum.attribute('assetsBaseUrl')}/extensions/fof-profile-image-crop/`);
 
 export const loadCropper = async () => {
   try {


### PR DESCRIPTION

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
If the forum uses a custom assets path/URI, we cannot use the `baseUrl` to determine where the external module is located.
